### PR TITLE
KMS-1879 only strip out comments if they are on their own lines

### DIFF
--- a/src/rigor/model.py
+++ b/src/rigor/model.py
@@ -160,15 +160,14 @@ class Case(object):
 
     @classmethod
     def strip_comments(cls, content):
+        # only strip out comments if they are on their own line
         no_comments_content = ''
         for line in content.splitlines(True):
             split_on_comment = line.split('#')
             line_content_before_comment = split_on_comment[0]
             stripped_before_comment = line_content_before_comment.strip()
             if stripped_before_comment is not '':
-                no_comments_content += line_content_before_comment
-                if len(split_on_comment) > 1:
-                    no_comments_content += '\n'
+                no_comments_content += line
         return no_comments_content
 
     @classmethod


### PR DESCRIPTION
Correction to last PR. Now, rigor will only strip out comments if they are on their own line. This is to prevent any issues in which a pound sign is required in the scenarios table.